### PR TITLE
Sort results

### DIFF
--- a/controllers/tagController.js
+++ b/controllers/tagController.js
@@ -1,7 +1,8 @@
+'use strict';
 var db = require('../db/db.js');
 
 module.exports = {
     createTag: tag => db.createTag(tag),
     getOneTag: tagName => db.retrieveTag(tagName),
-    getAllTags: () => db.retrieveAllTags()
+    getAllTags: sortBy => db.retrieveAllTags(sortBy)
 };

--- a/db/db.js
+++ b/db/db.js
@@ -1,4 +1,5 @@
 // TODO: tidy up promise chanins by using shallow chains
+'use strict';
 var db = require('../db/db.js'),
     mongoose = require('mongoose'),
     Tag = require('../models/tags.model.js');
@@ -53,8 +54,20 @@ module.exports = {
                 }
             }).exec();
     },
-    retrieveAllTags: function() {
-        return Tag.find().exec();
+    retrieveAllTags: (sortBy) => {
+        // TODO: replace default param style used below with 
+        // ES6 default function params when they are enabled
+        // in nodejs v6
+        sortBy = typeof sortBy == 'undefined' ? 'tag' : sortBy;
+        var sortPath = 'tags.' + sortBy;
+        var sortExpr = {};
+        sortExpr[sortPath] = 1;
+
+        return Tag.aggregate()
+            .unwind('tags')
+            .sort(sortExpr)
+            .group({_id:'$_id', tags: {$push:'$tags'}})
+            .exec();
     }
 };
 

--- a/routes.js
+++ b/routes.js
@@ -32,13 +32,8 @@ function getOneTag(req, res) {
 }
 
 function getAllTags(req, res) {
-    var sortBy;
-
     if (req.query.sortby) {
-        sortBy = req.query.sortby;
-    }
-    else {
-        sortBy = false;
+        var sortBy = req.query.sortby;
     }
 
     tagController.getAllTags(sortBy)

--- a/routes.js
+++ b/routes.js
@@ -32,7 +32,16 @@ function getOneTag(req, res) {
 }
 
 function getAllTags(req, res) {
-    tagController.getAllTags()
+    var sortBy;
+
+    if (req.query.sortby) {
+        sortBy = req.query.sortby;
+    }
+    else {
+        sortBy = false;
+    }
+
+    tagController.getAllTags(sortBy)
     .then(tags => res.json(tags))
     .catch(err => res.send(err).end());
 }


### PR DESCRIPTION
Results returned when client queries all tags are sorted by tag name by default or by any other key name. Right now that's relevance or _id.

Unfortunately ES6 default function parameters are not supported in node (coming in v6), so an ES5 compliant style has been used. 
